### PR TITLE
feat: make telescope optional

### DIFF
--- a/lua/quickgd/commands.lua
+++ b/lua/quickgd/commands.lua
@@ -2,9 +2,6 @@ local M = {}
 
 local fs = require("quickgd.lib.fs")
 local config = require("quickgd.lib.config")
-local telescope = require("quickgd.lib.telescope")
-local actions = telescope.actions
-local actions_state = telescope.actions_state
 
 function M.godot_start()
 	local command = string.format("silent! !%s %s", config.godot_path, config.project_path)
@@ -12,18 +9,22 @@ function M.godot_start()
 end
 
 function M.godot_run()
-	local function run_scene(prompt_bufnr)
-		actions.select_default:replace(function()
-			actions.close(prompt_bufnr)
-			local selected = actions_state.get_selected_entry()
-			config.last_scene = selected.path
-			local command = string.format("silent! !%s %s", config.godot_path, selected.path)
-			vim.api.nvim_command(command)
-		end)
-		return true
-	end
-
 	if config.telescope then
+		local telescope = require("quickgd.lib.telescope")
+		local actions = telescope.actions
+		local actions_state = telescope.actions_state
+
+		local function run_scene(prompt_bufnr)
+			actions.select_default:replace(function()
+				actions.close(prompt_bufnr)
+				local selected = actions_state.get_selected_entry()
+				config.last_scene = selected.path
+				local command = string.format("silent! !%s %s", config.godot_path, selected.path)
+				vim.api.nvim_command(command)
+			end)
+			return true
+		end
+
 		telescope.run_func_on_selected({
 			name = "TSCN",
 			attach_mappings = run_scene,

--- a/lua/quickgd/lib/config.lua
+++ b/lua/quickgd/lib/config.lua
@@ -15,7 +15,17 @@ function M.set_user_config(opts)
 	if opts.default then
 		error("User values are not stored in 'default'")
 	end
+
 	opts = vim.tbl_deep_extend("force", M.default, opts)
+
+	if opts.telescope then
+		local ok = pcall(require, "telescope")
+		if not ok then
+			opts.telescope = false
+			vim.notify("[quickgd] Telescope not found. Falling back to vim.ui.select.", vim.log.levels.WARN)
+		end
+	end
+
 	for key, value in pairs(opts) do
 		M[key] = value
 	end


### PR DESCRIPTION
Hey There,

Currently, it's not possible to use the fallback vim.ui.select since it does a require call to telescope inside `local telescope = require("quickgd.lib.telescope")`

I've moved this into the `if config.telescope then` check and I've updated the config so it will default to false if telescope isn't installed.

This should now allow other picks such as snacks or fzf without hard dying.

Thanks